### PR TITLE
Remove enum types with only one value (represent fixed values)

### DIFF
--- a/.circleci/golden/expected/src/OpenAPI/Operations/Patch_pets.hs
+++ b/.circleci/golden/expected/src/OpenAPI/Operations/Patch_pets.hs
@@ -52,9 +52,10 @@ patch_pets body = GHC.Base.fmap (\response_0 -> GHC.Base.fmap (Data.Either.eithe
 -- | Defines the oneOf schema located at @paths.\/pets.PATCH.requestBody.content.application\/json.schema.oneOf@ in the specification.
 -- 
 -- 
-data Patch_petsRequestBodyVariants
-    = Patch_petsRequestBodyCat Cat | Patch_petsRequestBodyDog Dog
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data Patch_petsRequestBodyVariants =
+   Patch_petsRequestBodyCat Cat
+  | Patch_petsRequestBodyDog Dog
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON Patch_petsRequestBodyVariants
     where toJSON (Patch_petsRequestBodyCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (Patch_petsRequestBodyDog a) = Data.Aeson.Types.ToJSON.toJSON a

--- a/.circleci/golden/expected/src/OpenAPI/Types/Cat.hs
+++ b/.circleci/golden/expected/src/OpenAPI/Types/Cat.hs
@@ -63,11 +63,11 @@ mkCat = Cat{catAge = GHC.Maybe.Nothing,
 -- | Defines the oneOf schema located at @components.schemas.Cat.properties.another_relative.oneOf@ in the specification.
 -- 
 -- 
-data CatAnother_relativeVariants
-    = CatAnother_relativeCat Cat
-    | CatAnother_relativePetByType PetByType
-    | CatAnother_relativeText Data.Text.Internal.Text
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data CatAnother_relativeVariants =
+   CatAnother_relativeCat Cat
+  | CatAnother_relativePetByType PetByType
+  | CatAnother_relativeText Data.Text.Internal.Text
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON CatAnother_relativeVariants
     where toJSON (CatAnother_relativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (CatAnother_relativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a
@@ -79,11 +79,11 @@ instance Data.Aeson.Types.FromJSON.FromJSON CatAnother_relativeVariants
 -- | Defines the oneOf schema located at @components.schemas.Cat.properties.relative.anyOf@ in the specification.
 -- 
 -- 
-data CatRelativeVariants
-    = CatRelativeCat Cat
-    | CatRelativePetByType PetByType
-    | CatRelativeText Data.Text.Internal.Text
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data CatRelativeVariants =
+   CatRelativeCat Cat
+  | CatRelativePetByType PetByType
+  | CatRelativeText Data.Text.Internal.Text
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON CatRelativeVariants
     where toJSON (CatRelativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (CatRelativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a

--- a/.circleci/golden/expected/src/OpenAPI/Types/Mischling.hs
+++ b/.circleci/golden/expected/src/OpenAPI/Types/Mischling.hs
@@ -148,23 +148,29 @@ mkMischlingAnother_relativeOneOf4 = MischlingAnother_relativeOneOf4{mischlingAno
 -- | Defines the oneOf schema located at @components.schemas.Mischling.allOf.properties.another_relative.oneOf@ in the specification.
 -- 
 -- 
-data MischlingAnother_relativeVariants
-    = MischlingAnother_relativeCat Cat
-    | MischlingAnother_relativePetByType PetByType
-    | MischlingAnother_relativeText Data.Text.Internal.Text
-    | MischlingAnother_relativeMischlingAnother_relativeOneOf4 MischlingAnother_relativeOneOf4
-    | MischlingAnother_relativeListTText ([Data.Text.Internal.Text])
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data MischlingAnother_relativeVariants =
+   MischlingAnother_relativeEmptyString -- ^ Represents the JSON value @""@
+  | MischlingAnother_relativeTest -- ^ Represents the JSON value @"test"@
+  | MischlingAnother_relativeCat Cat
+  | MischlingAnother_relativePetByType PetByType
+  | MischlingAnother_relativeText Data.Text.Internal.Text
+  | MischlingAnother_relativeMischlingAnother_relativeOneOf4 MischlingAnother_relativeOneOf4
+  | MischlingAnother_relativeListTText ([Data.Text.Internal.Text])
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON MischlingAnother_relativeVariants
     where toJSON (MischlingAnother_relativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (MischlingAnother_relativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (MischlingAnother_relativeText a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (MischlingAnother_relativeMischlingAnother_relativeOneOf4 a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (MischlingAnother_relativeListTText a) = Data.Aeson.Types.ToJSON.toJSON a
+          toJSON (MischlingAnother_relativeEmptyString) = ""
+          toJSON (MischlingAnother_relativeTest) = "test"
 instance Data.Aeson.Types.FromJSON.FromJSON MischlingAnother_relativeVariants
-    where parseJSON val = case (MischlingAnother_relativeCat Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((MischlingAnother_relativePetByType Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((MischlingAnother_relativeText Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((MischlingAnother_relativeMischlingAnother_relativeOneOf4 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((MischlingAnother_relativeListTText Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> Data.Aeson.Types.Internal.Error "No variant matched")))) of
-                              Data.Aeson.Types.Internal.Success a -> GHC.Base.pure a
-                              Data.Aeson.Types.Internal.Error a -> Control.Monad.Fail.fail a
+    where parseJSON val = if | val GHC.Classes.== "" -> GHC.Base.pure MischlingAnother_relativeEmptyString
+                             | val GHC.Classes.== "test" -> GHC.Base.pure MischlingAnother_relativeTest
+                             | GHC.Base.otherwise -> case (MischlingAnother_relativeCat Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((MischlingAnother_relativePetByType Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((MischlingAnother_relativeText Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((MischlingAnother_relativeMischlingAnother_relativeOneOf4 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((MischlingAnother_relativeListTText Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> Data.Aeson.Types.Internal.Error "No variant matched")))) of
+                                                         Data.Aeson.Types.Internal.Success a -> GHC.Base.pure a
+                                                         Data.Aeson.Types.Internal.Error a -> Control.Monad.Fail.fail a
 -- | Defines the enum schema located at @components.schemas.Mischling.allOf.properties.breed@ in the specification.
 -- 
 -- 
@@ -224,11 +230,11 @@ mkMischlingFirst_relative mischlingFirst_relativePet_type = MischlingFirst_relat
 -- | Defines the oneOf schema located at @components.schemas.Mischling.allOf.properties.first_relative.allOf.properties.another_relative.oneOf@ in the specification.
 -- 
 -- 
-data MischlingFirst_relativeAnother_relativeVariants
-    = MischlingFirst_relativeAnother_relativeCat Cat
-    | MischlingFirst_relativeAnother_relativePetByType PetByType
-    | MischlingFirst_relativeAnother_relativeText Data.Text.Internal.Text
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data MischlingFirst_relativeAnother_relativeVariants =
+   MischlingFirst_relativeAnother_relativeCat Cat
+  | MischlingFirst_relativeAnother_relativePetByType PetByType
+  | MischlingFirst_relativeAnother_relativeText Data.Text.Internal.Text
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON MischlingFirst_relativeAnother_relativeVariants
     where toJSON (MischlingFirst_relativeAnother_relativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (MischlingFirst_relativeAnother_relativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a
@@ -258,11 +264,11 @@ instance Data.Aeson.Types.FromJSON.FromJSON MischlingFirst_relativePet_type
 -- | Defines the oneOf schema located at @components.schemas.Mischling.allOf.properties.first_relative.allOf.properties.relative.anyOf@ in the specification.
 -- 
 -- 
-data MischlingFirst_relativeRelativeVariants
-    = MischlingFirst_relativeRelativeCat Cat
-    | MischlingFirst_relativeRelativePetByType PetByType
-    | MischlingFirst_relativeRelativeText Data.Text.Internal.Text
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data MischlingFirst_relativeRelativeVariants =
+   MischlingFirst_relativeRelativeCat Cat
+  | MischlingFirst_relativeRelativePetByType PetByType
+  | MischlingFirst_relativeRelativeText Data.Text.Internal.Text
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON MischlingFirst_relativeRelativeVariants
     where toJSON (MischlingFirst_relativeRelativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (MischlingFirst_relativeRelativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a
@@ -274,11 +280,11 @@ instance Data.Aeson.Types.FromJSON.FromJSON MischlingFirst_relativeRelativeVaria
 -- | Defines the oneOf schema located at @components.schemas.Mischling.allOf.properties.relative.anyOf@ in the specification.
 -- 
 -- 
-data MischlingRelativeVariants
-    = MischlingRelativeCat Cat
-    | MischlingRelativePetByType PetByType
-    | MischlingRelativeText Data.Text.Internal.Text
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data MischlingRelativeVariants =
+   MischlingRelativeCat Cat
+  | MischlingRelativePetByType PetByType
+  | MischlingRelativeText Data.Text.Internal.Text
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON MischlingRelativeVariants
     where toJSON (MischlingRelativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (MischlingRelativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a

--- a/.circleci/golden/expected/src/OpenAPI/Types/PetByAge.hs
+++ b/.circleci/golden/expected/src/OpenAPI/Types/PetByAge.hs
@@ -84,23 +84,29 @@ mkPetByAgeAnother_relativeOneOf4 = PetByAgeAnother_relativeOneOf4{petByAgeAnothe
 -- | Defines the oneOf schema located at @components.schemas.PetByAge.properties.another_relative.oneOf@ in the specification.
 -- 
 -- 
-data PetByAgeAnother_relativeVariants
-    = PetByAgeAnother_relativeCat Cat
-    | PetByAgeAnother_relativePetByType PetByType
-    | PetByAgeAnother_relativeText Data.Text.Internal.Text
-    | PetByAgeAnother_relativePetByAgeAnother_relativeOneOf4 PetByAgeAnother_relativeOneOf4
-    | PetByAgeAnother_relativeListTText ([Data.Text.Internal.Text])
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data PetByAgeAnother_relativeVariants =
+   PetByAgeAnother_relativeEmptyString -- ^ Represents the JSON value @""@
+  | PetByAgeAnother_relativeTest -- ^ Represents the JSON value @"test"@
+  | PetByAgeAnother_relativeCat Cat
+  | PetByAgeAnother_relativePetByType PetByType
+  | PetByAgeAnother_relativeText Data.Text.Internal.Text
+  | PetByAgeAnother_relativePetByAgeAnother_relativeOneOf4 PetByAgeAnother_relativeOneOf4
+  | PetByAgeAnother_relativeListTText ([Data.Text.Internal.Text])
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON PetByAgeAnother_relativeVariants
     where toJSON (PetByAgeAnother_relativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (PetByAgeAnother_relativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (PetByAgeAnother_relativeText a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (PetByAgeAnother_relativePetByAgeAnother_relativeOneOf4 a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (PetByAgeAnother_relativeListTText a) = Data.Aeson.Types.ToJSON.toJSON a
+          toJSON (PetByAgeAnother_relativeEmptyString) = ""
+          toJSON (PetByAgeAnother_relativeTest) = "test"
 instance Data.Aeson.Types.FromJSON.FromJSON PetByAgeAnother_relativeVariants
-    where parseJSON val = case (PetByAgeAnother_relativeCat Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((PetByAgeAnother_relativePetByType Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((PetByAgeAnother_relativeText Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((PetByAgeAnother_relativePetByAgeAnother_relativeOneOf4 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((PetByAgeAnother_relativeListTText Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> Data.Aeson.Types.Internal.Error "No variant matched")))) of
-                              Data.Aeson.Types.Internal.Success a -> GHC.Base.pure a
-                              Data.Aeson.Types.Internal.Error a -> Control.Monad.Fail.fail a
+    where parseJSON val = if | val GHC.Classes.== "" -> GHC.Base.pure PetByAgeAnother_relativeEmptyString
+                             | val GHC.Classes.== "test" -> GHC.Base.pure PetByAgeAnother_relativeTest
+                             | GHC.Base.otherwise -> case (PetByAgeAnother_relativeCat Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((PetByAgeAnother_relativePetByType Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((PetByAgeAnother_relativeText Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((PetByAgeAnother_relativePetByAgeAnother_relativeOneOf4 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((PetByAgeAnother_relativeListTText Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> Data.Aeson.Types.Internal.Error "No variant matched")))) of
+                                                         Data.Aeson.Types.Internal.Success a -> GHC.Base.pure a
+                                                         Data.Aeson.Types.Internal.Error a -> Control.Monad.Fail.fail a
 -- | Defines the object schema located at @components.schemas.PetByAge.properties.first_relative.allOf@ in the specification.
 -- 
 -- 
@@ -136,11 +142,11 @@ mkPetByAgeFirst_relative petByAgeFirst_relativePet_type = PetByAgeFirst_relative
 -- | Defines the oneOf schema located at @components.schemas.PetByAge.properties.first_relative.allOf.properties.another_relative.oneOf@ in the specification.
 -- 
 -- 
-data PetByAgeFirst_relativeAnother_relativeVariants
-    = PetByAgeFirst_relativeAnother_relativeCat Cat
-    | PetByAgeFirst_relativeAnother_relativePetByType PetByType
-    | PetByAgeFirst_relativeAnother_relativeText Data.Text.Internal.Text
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data PetByAgeFirst_relativeAnother_relativeVariants =
+   PetByAgeFirst_relativeAnother_relativeCat Cat
+  | PetByAgeFirst_relativeAnother_relativePetByType PetByType
+  | PetByAgeFirst_relativeAnother_relativeText Data.Text.Internal.Text
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON PetByAgeFirst_relativeAnother_relativeVariants
     where toJSON (PetByAgeFirst_relativeAnother_relativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (PetByAgeFirst_relativeAnother_relativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a
@@ -170,11 +176,11 @@ instance Data.Aeson.Types.FromJSON.FromJSON PetByAgeFirst_relativePet_type
 -- | Defines the oneOf schema located at @components.schemas.PetByAge.properties.first_relative.allOf.properties.relative.anyOf@ in the specification.
 -- 
 -- 
-data PetByAgeFirst_relativeRelativeVariants
-    = PetByAgeFirst_relativeRelativeCat Cat
-    | PetByAgeFirst_relativeRelativePetByType PetByType
-    | PetByAgeFirst_relativeRelativeText Data.Text.Internal.Text
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data PetByAgeFirst_relativeRelativeVariants =
+   PetByAgeFirst_relativeRelativeCat Cat
+  | PetByAgeFirst_relativeRelativePetByType PetByType
+  | PetByAgeFirst_relativeRelativeText Data.Text.Internal.Text
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON PetByAgeFirst_relativeRelativeVariants
     where toJSON (PetByAgeFirst_relativeRelativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (PetByAgeFirst_relativeRelativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a
@@ -186,11 +192,11 @@ instance Data.Aeson.Types.FromJSON.FromJSON PetByAgeFirst_relativeRelativeVarian
 -- | Defines the oneOf schema located at @components.schemas.PetByAge.properties.relative.anyOf@ in the specification.
 -- 
 -- 
-data PetByAgeRelativeVariants
-    = PetByAgeRelativeCat Cat
-    | PetByAgeRelativePetByType PetByType
-    | PetByAgeRelativeText Data.Text.Internal.Text
-    deriving (GHC.Show.Show, GHC.Classes.Eq)
+data PetByAgeRelativeVariants =
+   PetByAgeRelativeCat Cat
+  | PetByAgeRelativePetByType PetByType
+  | PetByAgeRelativeText Data.Text.Internal.Text
+  deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON PetByAgeRelativeVariants
     where toJSON (PetByAgeRelativeCat a) = Data.Aeson.Types.ToJSON.toJSON a
           toJSON (PetByAgeRelativePetByType a) = Data.Aeson.Types.ToJSON.toJSON a

--- a/.circleci/specifications/z_complex_self_made_example.yml
+++ b/.circleci/specifications/z_complex_self_made_example.yml
@@ -141,6 +141,12 @@ components:
             - $ref: '#/components/schemas/Cat'
             - $ref: '#/components/schemas/PetByType'
             - type: string
+            - type: string
+              enum:
+                - ''
+            - type: string
+              enum:
+                - test
             - type: array
               items:
                 type: string

--- a/.circleci/testing/level2/stripe/test/Spec.hs
+++ b/.circleci/testing/level2/stripe/test/Spec.hs
@@ -21,7 +21,6 @@ paymentIntent =
     "CHF"
     "123"
     False
-    PaymentIntentObject'EnumPaymentIntent
     []
     PaymentIntentStatus'EnumSucceeded
 
@@ -66,7 +65,6 @@ successResponseGetExpected =
   GetPaymentIntentsResponseBody200
     { getPaymentIntentsResponseBody200Data = [paymentIntent],
       getPaymentIntentsResponseBody200HasMore = False,
-      getPaymentIntentsResponseBody200Object = GetPaymentIntentsResponseBody200Object'EnumList,
       getPaymentIntentsResponseBody200Url = "http://example.org"
     }
 


### PR DESCRIPTION
Stripe uses enum schemas with only one possible value to represent fixed values. Those values are not useful in a statically typed environment as no discriminator is needed. The corresponding types are removed with this PR resulting in 439 less data definitions and a compile speed-up of around 10%.

https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/issues/29