### PR TITLE
Generate HasField instances for record-dot-preprocessor usage

### DIFF
--- a/openapi3-code-generator/openapi3-code-generator.cabal
+++ b/openapi3-code-generator/openapi3-code-generator.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2c9baa547ea20206f8e472e0e4f9ff734130ea57706161cab7392ab633117890
+-- hash: 3986e6b54b70c5c0f96dbea48679efbd9fa6f149b9f905c877b441555204b7b7
 
 name:           openapi3-code-generator
 version:        0.1.0.6
@@ -68,6 +68,7 @@ library
     , http-types
     , mtl
     , optparse-applicative
+    , record-hasfield
     , scientific
     , split
     , template-haskell
@@ -100,6 +101,7 @@ executable openapi3-code-generator-exe
     , mtl
     , openapi3-code-generator
     , optparse-applicative
+    , record-hasfield
     , scientific
     , split
     , template-haskell
@@ -145,6 +147,7 @@ test-suite openapi3-code-generator-test
     , mtl
     , openapi3-code-generator
     , optparse-applicative
+    , record-hasfield
     , scientific
     , split
     , template-haskell

--- a/openapi3-code-generator/package.yaml
+++ b/openapi3-code-generator/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - hashmap
 - directory
 - filepath
+- record-hasfield
 
 library:
   source-dirs: src

--- a/openapi3-code-generator/src/OpenAPI/Generate/Doc.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Doc.hs
@@ -181,9 +181,12 @@ sideBySide leftDoc rightDoc =
 addOperationsModuleHeader :: String -> String -> String -> Doc -> Doc
 addOperationsModuleHeader mainModuleName moduleName operationId =
   generatorNote
-    . languageExtension "OverloadedStrings"
+    . languageExtension "DataKinds"
     . languageExtension "ExplicitForAll"
+    . languageExtension "FlexibleInstances"
+    . languageExtension "MultiParamTypeClasses"
     . languageExtension "MultiWayIf"
+    . languageExtension "OverloadedStrings"
     . emptyLine
     . moduleDescription ("Contains the different functions to run the operation " <> operationId)
     . moduleDeclaration (mainModuleName <> ".Operations") moduleName
@@ -213,6 +216,7 @@ addOperationsModuleHeader mainModuleName moduleName operationId =
     . importQualified "GHC.Int"
     . importQualified "GHC.Show"
     . importQualified "GHC.Types"
+    . importQualified "GHC.Records.Compat"
     . importQualified "Network.HTTP.Client"
     . importQualified "Network.HTTP.Client as Network.HTTP.Client.Request"
     . importQualified "Network.HTTP.Client as Network.HTTP.Client.Types"
@@ -228,8 +232,12 @@ addOperationsModuleHeader mainModuleName moduleName operationId =
 addModelModuleHeader :: String -> String -> [String] -> String -> Doc -> Doc
 addModelModuleHeader mainModuleName moduleName modelModulesToImport description =
   generatorNote
-    . languageExtension "OverloadedStrings"
+    . languageExtension "DataKinds"
+    . languageExtension "ExplicitForAll"
+    . languageExtension "FlexibleInstances"
+    . languageExtension "MultiParamTypeClasses"
     . languageExtension "MultiWayIf"
+    . languageExtension "OverloadedStrings"
     . emptyLine
     . moduleDescription description
     . moduleDeclaration mainModuleName moduleName
@@ -256,6 +264,7 @@ addModelModuleHeader mainModuleName moduleName modelModulesToImport description 
     . importQualified "GHC.Int"
     . importQualified "GHC.Show"
     . importQualified "GHC.Types"
+    . importQualified "GHC.Records.Compat"
     . importQualified (mainModuleName <> ".Common")
     . (if moduleName == typeAliasModule then id else importUnqualified (mainModuleName <> "." <> typeAliasModule))
     . (vcat (fmap (text . ("import {-# SOURCE #-} " <>) . ((mainModuleName <> ".") <>)) modelModulesToImport) $$)

--- a/openapi3-code-generator/src/OpenAPI/Generate/IO.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/IO.hs
@@ -71,6 +71,7 @@ stackProjectFiles packageName moduleName modulesToExport =
                "    , time",
                "    , mtl",
                "    , transformers",
+               "    , record-hasfield",
                "  default-language: Haskell2010"
              ]
     ),

--- a/openapi3-code-generator/src/OpenAPI/Generate/Internal/Operation.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Internal/Operation.hs
@@ -121,8 +121,7 @@ generateParameterType operationName parameters = OAM.nested "parameters" $ do
       properties <-
         mapM
           ( \((parameter, _), schema) -> do
-              prefix <- getParameterLocationPrefix parameter
-              pure (prefix <> uppercaseFirstText (getNameFromParameter parameter), schema)
+              pure (getNameFromParameter parameter, schema)
           )
           parametersWithSchemas
       let parametersWithNames = zip (fst <$> properties) (fst <$> parametersWithSchemas)


### PR DESCRIPTION
> Note: this is more of a show and tell than a serious attempt at getting something merged. Maybe someone else will find this useful given the changes are easily applied to a generator fork, if desired.

[record-dot-preprocessor](https://hackage.haskell.org/package/record-dot-preprocessor) is something I use pervasively to improve the ergonomics of generated code, as a stop gap until [RecordDotSyntax](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0282-record-dot-syntax.rst) syntax starts shipping with GHC. It improves Haskell's record situation and particularly important for generated code, allows the use of duplicate field names with good inference without polluting your namespace(s) with ambiguous record selectors.

This PR generates `HasField` instances that are forwards/backwards compatible with `RecordDotSyntax` and allows you to use the original Stripe API field names which are both considerably briefer than the generated prefixes and also align nicely with the Stripe API documentation.

Code generation:

```
# No changes to the currently generated data type:
data AccountCapabilities = AccountCapabilities {
  accountCapabilitiesCardIssuing :: (GHC.Maybe.Maybe AccountCapabilitiesCardIssuing'),
  accountCapabilitiesCardPayments :: (GHC.Maybe.Maybe AccountCapabilitiesCardPayments'),
  accountCapabilitiesLegacyPayments :: (GHC.Maybe.Maybe AccountCapabilitiesLegacyPayments'),
  accountCapabilitiesTransfers :: (GHC.Maybe.Maybe AccountCapabilitiesTransfers')
  }

# A HasField instance is generated per record selector, matching the JSON property name:
instance HasField "card_issuing" AccountCapabilities (Maybe AccountCapabilitiesCardIssuing') where
  hasField r = (\a -> r{accountCapabilitiesCardIssuing = a}, accountCapabilitiesCardIssuing r)

...
```

Usage with `record-dot-preprocessor` enabled:

```
let foo = AccountCapabilities{ 
    card_issuing = Nothing, 
    card_payments = Nothing, 
    legacy_payments = Nothing, 
    transfers = Nothing 
  }

let bar = foo.card_issuing
let baz = foo.transfers
...
```

Impact:

- `record-hasfield` dependency in the generator and generated library.
- `DataKinds`, `FlexibleInstances` and `MultiParamTypeClasses` extensions enabled in generated type and operation modules.

See:

- https://hackage.haskell.org/package/record-dot-preprocessor
- https://hackage.haskell.org/package/record-hasfield
- https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0282-record-dot-syntax.rst