### PR TITLE
split build support files, add OutputFiles type, Nix files

### DIFF
--- a/openapi3-code-generator/src/OpenAPI/Generate.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- | Functionality to Generate Haskell Code out of an OpenAPI definition File
 module OpenAPI.Generate where
@@ -45,7 +46,7 @@ runGenerator =
         let flags = OAO.optFlags options
         spec <- decodeOpenApi $ OAO.optSpecification options
         generatorConfiguration <- maybe (pure Nothing) ((pure . Just) <=< decodeGeneratorConfiguration) $ OAO.flagGeneratorConfigurationFile flags
-        (moduleFiles, projectFiles) <- OAI.generateFilesToCreate spec options generatorConfiguration
+        outFiles@OAI.OutputFiles {..} <- OAI.generateFilesToCreate spec options generatorConfiguration
         if OAO.flagDryRun flags
           then
             mapM_
@@ -60,6 +61,6 @@ runGenerator =
             proceed <- OAI.permitProceed flags
             if proceed
               then do
-                OAI.writeFiles flags moduleFiles projectFiles
+                OAI.writeFiles flags outFiles
                 putStrLn "finished"
               else putStrLn "aborted"

--- a/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
@@ -50,6 +50,8 @@ data Flags = Flags
     flagDryRun :: Bool,
     -- | Do not generate a stack project alongside the raw Haskell files
     flagDoNotGenerateStackProject :: Bool,
+    -- | Do not generate Nix files (default.nix and shell.nix)
+    flagDoNotGenerateNixFiles :: Bool,
     -- | Omit the additional operation functions, which are: with explicit configuration and raw variants (returning the plain ByteString) for both with and without explicit configuration
     flagOmitAdditionalOperationFunctions :: Bool,
     -- | Force the generator to create types for empty request bodies which are optional (e. g. no properties and required equals false)
@@ -107,6 +109,7 @@ parseFlags =
     <*> parseFlagIncremental
     <*> parseFlagDryRun
     <*> parseFlagDoNotGenerateStackProject
+    <*> parseFlagDoNotGenerateNixFiles
     <*> parseFlagOmitAdditionalOperationFunctions
     <*> parseFlagGenerateOptionalEmptyRequestBody
     <*> parseFlagUseNumberedVariantConstructors
@@ -215,6 +218,14 @@ parseFlagDoNotGenerateStackProject =
     mconcat
       [ help "Do not generate a stack project alongside the raw Haskell files",
         long "do-not-generate-stack-project"
+      ]
+
+parseFlagDoNotGenerateNixFiles :: Parser Bool
+parseFlagDoNotGenerateNixFiles =
+  switch $
+    mconcat
+      [ help "Do not generate Nix files alongside the raw Haskell files",
+        long "do-not-generate-nix-files"
       ]
 
 parseFlagOmitAdditionalOperationFunctions :: Parser Bool


### PR DESCRIPTION
Introduces `OutputFiles` that encapsulates all outputs.

Extends output with Nix files (minimal default.nix and shell.nix)
unless disabled by `--do-not-generate-nix-files` flag.