### PR TITLE
Warn about operations and schemas listed in the CLI options but do no…

### DIFF
--- a/openapi3-code-generator/openapi3-code-generator.cabal
+++ b/openapi3-code-generator/openapi3-code-generator.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b03c3f2c843d0d59dd148c8998714934dd5293adfa20e611ffdae06c9fc5160f
+-- hash: ce09bab9bf2cd9abcdcbb08ca77f5a142be37defb8fcbcb103537deea1f3102c
 
 name:           openapi3-code-generator
 version:        0.1.0.6
@@ -33,6 +33,7 @@ library
       OpenAPI.Generate.Doc
       OpenAPI.Generate.Internal.Embed
       OpenAPI.Generate.Internal.Operation
+      OpenAPI.Generate.Internal.Unknown
       OpenAPI.Generate.Internal.Util
       OpenAPI.Generate.IO
       OpenAPI.Generate.Log

--- a/openapi3-code-generator/src/OpenAPI/Generate/Internal/Unknown.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Internal/Unknown.hs
@@ -27,13 +27,13 @@ warnAboutUnknownOperations operationDefinitions = do
           Maybe.catMaybes $
             operationDefinitions >>= getAllOperationObjectsFromPathItemObject . snd
   operationsToGenerate <- OAM.getFlag OAO.flagOperationsToGenerate
-  printWarningIfUnknown (\operationId proposedOptions -> "The operation '" <> operationId <> "' which is listed for generation does not appear in the provided OpenAPI specification (" <> proposedOptions <> ").") operationIds operationsToGenerate
+  printWarningIfUnknown (\operationId proposedOptions -> "The operation '" <> operationId <> "' which is listed for generation does not appear in the provided OpenAPI specification. " <> proposedOptions) operationIds operationsToGenerate
 
 -- | Warn about schemas listed as CLI options (white list or opaque schemas) which do not appear in the provided OpenAPI specification
 warnAboutUnknownWhiteListedOrOpaqueSchemas :: [(Text, OAS.Schema)] -> OAM.Generator ()
 warnAboutUnknownWhiteListedOrOpaqueSchemas schemaDefinitions = do
   let schemaNames = fst <$> schemaDefinitions
-      printWarningIfUnknownWithTypeName typeName = printWarningIfUnknown (\name proposedOptions -> "The " <> typeName <> " '" <> name <> "' does not appear in the provided OpenAPI specification (" <> proposedOptions <> ").") schemaNames
+      printWarningIfUnknownWithTypeName typeName = printWarningIfUnknown (\name proposedOptions -> "The " <> typeName <> " '" <> name <> "' does not appear in the provided OpenAPI specification. " <> proposedOptions) schemaNames
   whiteListedSchemas <- OAM.getFlag OAO.flagWhiteListedSchemas
   opaqueSchemas <- OAM.getFlag OAO.flagOpaqueSchemas
   printWarningIfUnknownWithTypeName "white-listed schema" whiteListedSchemas
@@ -54,9 +54,11 @@ sortByLongestCommonSubstring :: Text -> [Text] -> [Text]
 sortByLongestCommonSubstring needle = fmap fst . L.sortOn snd . fmap (\x -> (x, - (longestCommonSubstringCount needle x)))
 
 getProposedOptions :: [Text] -> Text
-getProposedOptions [] = "Specification does not contain any"
+getProposedOptions [] = "Specification does not contain any."
 getProposedOptions (x1 : x2 : x3 : _ : _) = getProposedOptions [x1, x2, x3]
-getProposedOptions xs = "Did you mean one of following options? " <> T.intercalate ", " xs
+getProposedOptions xs =
+  let separator = "\n      "
+   in "Did you mean one of following options?" <> separator <> T.intercalate separator xs
 
 longestCommonSubstringCount :: Text -> Text -> Int
 longestCommonSubstringCount x y =

--- a/openapi3-code-generator/src/OpenAPI/Generate/Internal/Unknown.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Internal/Unknown.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module OpenAPI.Generate.Internal.Unknown
+  ( warnAboutUnknownWhiteListedOrOpaqueSchemas,
+    warnAboutUnknownOperations,
+  )
+where
+
+import Control.Monad
+import qualified Data.List as L
+import qualified Data.Maybe as Maybe
+import qualified Data.Ord as Ord
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified OpenAPI.Generate.Monad as OAM
+import qualified OpenAPI.Generate.OptParse as OAO
+import qualified OpenAPI.Generate.Types as OAT
+import qualified OpenAPI.Generate.Types.Schema as OAS
+
+-- | Warn about operations listed as CLI options which do not appear in the provided OpenAPI specification
+warnAboutUnknownOperations :: [(Text, OAT.PathItemObject)] -> OAM.Generator ()
+warnAboutUnknownOperations operationDefinitions = do
+  let getAllOperationObjectsFromPathItemObject = ([OAT.get, OAT.put, OAT.post, OAT.delete, OAT.options, OAT.head, OAT.patch, OAT.trace] <*>) . pure
+      operationIds =
+        Maybe.mapMaybe OAT.operationId $
+          Maybe.catMaybes $
+            operationDefinitions >>= getAllOperationObjectsFromPathItemObject . snd
+  operationsToGenerate <- OAM.getFlag OAO.flagOperationsToGenerate
+  printWarningIfUnknown (\operationId proposedOptions -> "The operation '" <> operationId <> "' which is listed for generation does not appear in the provided OpenAPI specification (" <> proposedOptions <> ").") operationIds operationsToGenerate
+
+-- | Warn about schemas listed as CLI options (white list or opaque schemas) which do not appear in the provided OpenAPI specification
+warnAboutUnknownWhiteListedOrOpaqueSchemas :: [(Text, OAS.Schema)] -> OAM.Generator ()
+warnAboutUnknownWhiteListedOrOpaqueSchemas schemaDefinitions = do
+  let schemaNames = fst <$> schemaDefinitions
+      printWarningIfUnknownWithTypeName typeName = printWarningIfUnknown (\name proposedOptions -> "The " <> typeName <> " '" <> name <> "' does not appear in the provided OpenAPI specification (" <> proposedOptions <> ").") schemaNames
+  whiteListedSchemas <- OAM.getFlag OAO.flagWhiteListedSchemas
+  opaqueSchemas <- OAM.getFlag OAO.flagOpaqueSchemas
+  printWarningIfUnknownWithTypeName "white-listed schema" whiteListedSchemas
+  printWarningIfUnknownWithTypeName "schema listed as opaque" opaqueSchemas
+
+printWarningIfUnknown :: (Text -> Text -> Text) -> [Text] -> [Text] -> OAM.Generator ()
+printWarningIfUnknown generateMessage namesFromSpecification =
+  mapM_
+    ( \name -> do
+        unless (name `elem` namesFromSpecification) $
+          OAM.logWarning $ generateMessage name $ getProposedOptionsFromNameAndAvailableSchemas name namesFromSpecification
+    )
+
+getProposedOptionsFromNameAndAvailableSchemas :: Text -> [Text] -> Text
+getProposedOptionsFromNameAndAvailableSchemas name = getProposedOptions . sortByLongestCommonSubstring name
+
+sortByLongestCommonSubstring :: Text -> [Text] -> [Text]
+sortByLongestCommonSubstring needle = fmap fst . L.sortOn snd . fmap (\x -> (x, - (longestCommonSubstringCount needle x)))
+
+getProposedOptions :: [Text] -> Text
+getProposedOptions [] = "Specification does not contain any"
+getProposedOptions (x1 : x2 : x3 : _ : _) = getProposedOptions [x1, x2, x3]
+getProposedOptions xs = "Did you mean one of following options? " <> T.intercalate ", " xs
+
+longestCommonSubstringCount :: Text -> Text -> Int
+longestCommonSubstringCount x y =
+  let getSetWithAllSubstrings = Set.fromList . (T.inits <=< T.tails) . T.toLower
+      intersection = Set.intersection (getSetWithAllSubstrings x) (getSetWithAllSubstrings y)
+   in if Set.null intersection then 0 else T.length (L.maximumBy (Ord.comparing T.length) intersection)

--- a/openapi3-code-generator/src/OpenAPI/Generate/Internal/Unknown.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Internal/Unknown.hs
@@ -42,7 +42,7 @@ warnAboutUnknownWhiteListedOrOpaqueSchemas schemaDefinitions = do
 printWarningIfUnknown :: (Text -> Text -> Text) -> [Text] -> [Text] -> OAM.Generator ()
 printWarningIfUnknown generateMessage namesFromSpecification =
   mapM_
-    ( \name -> do
+    ( \name ->
         unless (name `elem` namesFromSpecification) $
           OAM.logWarning $ generateMessage name $ getProposedOptionsFromNameAndAvailableSchemas name namesFromSpecification
     )


### PR DESCRIPTION
…t exist in the specification

Example output:

Generating Stripe specification with --white-listed-schema=acounts --operation-to-generate=GetChekout
```
WARN  (paths): The operation 'GetChekout' which is listed for generation does not appear in the provided OpenAPI specification (Did you mean one of following options? GetCheckoutSessions, GetCheckoutSessionsSession, GetCharges).
WARN  (components.schemas): The white-listed schema 'acounts' does not appear in the provided OpenAPI specification (Did you mean one of following options? account, account_branding_settings, account_business_profile).
```

Generating Stripe specification with --operation-to-generate=GetCheckout
```
WARN  (paths): The operation 'GetCheckout' which is listed for generation does not appear in the provided OpenAPI specification (Did you mean one of following options? GetCheckoutSessions, GetCheckoutSessionsSession, PostCheckoutSessions).
```

Generating Stripe specification with --operation-to-generate=invoice
```
WARN  (paths): The operation 'invoice' which is listed for generation does not appear in the provided OpenAPI specification (Did you mean one of following options? GetInvoiceitems, PostInvoiceitems, GetInvoiceitemsInvoiceitem).
```