### PR TITLE
Fix style "form" with and without explode for query params

### DIFF
--- a/.circleci/specifications/petstore-running-example.yaml
+++ b/.circleci/specifications/petstore-running-example.yaml
@@ -589,6 +589,66 @@ paths:
               "$ref": "#/components/schemas/NullableAndOptionalTest"
         description: Nullable and optional values as input
         required: true
+  /query/array/form:
+    get:
+      operationId: queryArrayForm
+      parameters:
+      - name: color
+        in: query
+        required: true
+        style: form
+        explode: false
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: Worked
+  /query/array/form-explode:
+    get:
+      operationId: queryArrayFormExplode
+      parameters:
+      - name: color
+        in: query
+        required: true
+        style: form
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: Worked
+  /query/object/form:
+    get:
+      operationId: queryObjectForm
+      parameters:
+      - name: color
+        in: query
+        required: true
+        style: form
+        explode: false
+        schema:
+          "$ref": "#/components/schemas/RGBObject"
+      responses:
+        '200':
+          description: Worked
+  /query/object/form-explode:
+    get:
+      operationId: queryObjectFormExplode
+      parameters:
+      - name: color
+        in: query
+        required: true
+        style: form
+        explode: true
+        schema:
+          "$ref": "#/components/schemas/RGBObject"
+      responses:
+        '200':
+          description: Worked
 externalDocs:
   description: Find out more about Swagger
   url: http://swagger.io
@@ -742,6 +802,19 @@ components:
       type: string
     NonNullableString:
       type: string
+    RGBObject:
+      type: object
+      required:
+        - R
+        - G
+        - B
+      properties:
+        R:
+          type: number
+        G:
+          type: number
+        B:
+          type: number
   requestBodies:
     Pet:
       content:

--- a/.circleci/testing/level2/petstore-running-example/test/Spec.hs
+++ b/.circleci/testing/level2/petstore-running-example/test/Spec.hs
@@ -62,3 +62,32 @@ main =
         let requestExpectation = expectBody "{\"name\":\"Tag 1\",\"id\":3}" $ expectMethod "PUT" noExpectation
         response <- runMock runUpdatePetWithTag (requestExpectation, succeededResponse)
         getResponseBody response `shouldBe` UpdatePetResponse200
+
+    describe "query param styles should produce correct output" $ do
+      let arrayValues = ["blue", "black", "brown"]
+          objectValue =
+            RGBObject
+              { rGBObjectR = 100,
+                rGBObjectG = 200,
+                rGBObjectB = 150
+              }
+
+      it "array form with explode = false" $ do
+        let requestExpectation = expectURL "http://localhost:8887/query/array/form?color=blue%2Cblack%2Cbrown" $ expectMethod "GET" noExpectation
+        response <- runMock (queryArrayFormWithConfiguration defaultConfiguration arrayValues) (requestExpectation, succeededResponse)
+        getResponseBody response `shouldBe` QueryArrayFormResponse200
+
+      it "array form with explode = true" $ do
+        let requestExpectation = expectURL "http://localhost:8887/query/array/form-explode?color=blue&color=black&color=brown" $ expectMethod "GET" noExpectation
+        response <- runMock (queryArrayFormExplodeWithConfiguration defaultConfiguration arrayValues) (requestExpectation, succeededResponse)
+        getResponseBody response `shouldBe` QueryArrayFormExplodeResponse200
+
+      it "object form with explode = false" $ do
+        let requestExpectation = expectURL "http://localhost:8887/query/object/form?color=G%2C200%2CB%2C150%2CR%2C100" $ expectMethod "GET" noExpectation
+        response <- runMock (queryObjectFormWithConfiguration defaultConfiguration objectValue) (requestExpectation, succeededResponse)
+        getResponseBody response `shouldBe` QueryObjectFormResponse200
+
+      it "object form with explode = true" $ do
+        let requestExpectation = expectURL "http://localhost:8887/query/object/form-explode?G=200&B=150&R=100" $ expectMethod "GET" noExpectation
+        response <- runMock (queryObjectFormExplodeWithConfiguration defaultConfiguration objectValue) (requestExpectation, succeededResponse)
+        getResponseBody response `shouldBe` QueryObjectFormExplodeResponse200


### PR DESCRIPTION
Fixed style "form" for query params according to the [examples in the specification](https://spec.openapis.org/oas/v3.0.3#style-examples).

Fixes https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/issues/74