### PR TITLE
Change Path package import to enable to work with Windows paths

### DIFF
--- a/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
@@ -22,8 +22,8 @@ import OpenAPI.Generate.OptParse.Flags
 import OpenAPI.Generate.OptParse.Types
 import Options.Applicative
 import Options.Applicative.Help (string)
-import Path.IO
 import Path
+import Path.IO
 import System.Exit
 
 getSettings :: IO Settings

--- a/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
@@ -23,7 +23,7 @@ import OpenAPI.Generate.OptParse.Types
 import Options.Applicative
 import Options.Applicative.Help (string)
 import Path.IO
-import Path.Posix
+import Path
 import System.Exit
 
 getSettings :: IO Settings


### PR DESCRIPTION
Change import statement from `import Path.Posix` to `import Path` to avoid bugs when building the library on a Windows OS. Importing `Path` on its own is usually better: [Hackage Path](https://hackage.haskell.org/package/path-0.9.2/docs/Path-Posix.html#:~:text=Importing%20Path%20is%20usually%20better.).