### PR TITLE
multipleOf and Data.Text import fix

### DIFF
--- a/openapi3-code-generator/src/OpenAPI/Generate/Doc.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Doc.hs
@@ -209,7 +209,7 @@ addOperationsModuleHeader mainModuleName moduleName operationId =
     . importQualified "Data.Maybe"
     . importQualified "Data.Scientific"
     . importQualified "Data.Text"
-    . importQualified "Data.Text.Internal"
+    . importQualified "Data.Text as Data.Text.Internal"
     . importQualified "Data.Time.Calendar as Data.Time.Calendar.Days"
     . importQualified "Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime"
     . importQualified "Data.Vector"
@@ -255,7 +255,7 @@ addModelModuleHeader mainModuleName moduleName modelModulesToImport description 
     . importQualified "Data.Maybe"
     . importQualified "Data.Scientific"
     . importQualified "Data.Text"
-    . importQualified "Data.Text.Internal"
+    . importQualified "Data.Text as Data.Text.Internal"
     . importQualified "Data.Time.Calendar as Data.Time.Calendar.Days"
     . importQualified "Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime"
     . importQualified "GHC.Base"
@@ -277,7 +277,7 @@ addSecuritySchemesModuleHeader moduleName =
     . moduleDescription "Contains all supported security schemes defined in the specification"
     . moduleDeclaration moduleName "SecuritySchemes"
     . emptyLine
-    . importQualified "Data.Text.Internal"
+    . importQualified "Data.Text as Data.Text.Internal"
     . importQualified "GHC.Base"
     . importQualified "GHC.Classes"
     . importQualified "GHC.Show"
@@ -296,7 +296,7 @@ addConfigurationModuleHeader moduleName =
     . moduleDeclaration moduleName "Configuration"
     . emptyLine
     . importQualified "Data.Text"
-    . importQualified "Data.Text.Internal"
+    . importQualified "Data.Text as Data.Text.Internal"
     . importQualified "GHC.Types "
     . importQualified (moduleName <> ".Common")
     . emptyLine

--- a/openapi3-code-generator/src/OpenAPI/Generate/Types/Schema.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Types/Schema.hs
@@ -28,7 +28,7 @@ type Schema = Referencable SchemaObject
 data SchemaObject = SchemaObject
   { schemaObjectType :: SchemaType,
     schemaObjectTitle :: Maybe Text,
-    schemaObjectMultipleOf :: Maybe Integer,
+    schemaObjectMultipleOf :: Maybe Float,
     schemaObjectMaximum :: Maybe Float,
     schemaObjectExclusiveMaximum :: Bool,
     schemaObjectMinimum :: Maybe Float,

--- a/specifications/z_complex_self_made_example.yml
+++ b/specifications/z_complex_self_made_example.yml
@@ -235,11 +235,13 @@ components:
         int64:
           type: integer
           format: int64
+          multipleOf: 4
         number:
           type: number
         float:
           type: number
           format: float
+          multipleOf: 0.01
         double:
           type: number
           format: double

--- a/testing/golden-output/src/OpenAPI/Configuration.hs
+++ b/testing/golden-output/src/OpenAPI/Configuration.hs
@@ -6,7 +6,7 @@
 module OpenAPI.Configuration where
 
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified GHC.Types 
 import qualified OpenAPI.Common
 

--- a/testing/golden-output/src/OpenAPI/Operations/MultiParam.hs
+++ b/testing/golden-output/src/OpenAPI/Operations/MultiParam.hs
@@ -26,7 +26,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified Data.Vector

--- a/testing/golden-output/src/OpenAPI/Operations/MultiParamWithFixedEnum.hs
+++ b/testing/golden-output/src/OpenAPI/Operations/MultiParamWithFixedEnum.hs
@@ -26,7 +26,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified Data.Vector

--- a/testing/golden-output/src/OpenAPI/Operations/NoParam.hs
+++ b/testing/golden-output/src/OpenAPI/Operations/NoParam.hs
@@ -26,7 +26,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified Data.Vector

--- a/testing/golden-output/src/OpenAPI/Operations/Patch_pets.hs
+++ b/testing/golden-output/src/OpenAPI/Operations/Patch_pets.hs
@@ -26,7 +26,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified Data.Vector

--- a/testing/golden-output/src/OpenAPI/Operations/ShowPetById.hs
+++ b/testing/golden-output/src/OpenAPI/Operations/ShowPetById.hs
@@ -26,7 +26,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified Data.Vector

--- a/testing/golden-output/src/OpenAPI/Operations/SingleParam.hs
+++ b/testing/golden-output/src/OpenAPI/Operations/SingleParam.hs
@@ -26,7 +26,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified Data.Vector

--- a/testing/golden-output/src/OpenAPI/Operations/SingleParamWithFixedEnum.hs
+++ b/testing/golden-output/src/OpenAPI/Operations/SingleParamWithFixedEnum.hs
@@ -26,7 +26,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified Data.Vector

--- a/testing/golden-output/src/OpenAPI/SecuritySchemes.hs
+++ b/testing/golden-output/src/OpenAPI/SecuritySchemes.hs
@@ -5,7 +5,7 @@
 -- | Contains all supported security schemes defined in the specification
 module OpenAPI.SecuritySchemes where
 
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified GHC.Base
 import qualified GHC.Classes
 import qualified GHC.Show

--- a/testing/golden-output/src/OpenAPI/TypeAlias.hs
+++ b/testing/golden-output/src/OpenAPI/TypeAlias.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/Cat.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Cat.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/CoverType.hs
+++ b/testing/golden-output/src/OpenAPI/Types/CoverType.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/Dog.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Dog.hs
@@ -50,10 +50,18 @@ data Dog = Dog {
   -- | father
   , dogFather :: (GHC.Maybe.Maybe Data.Aeson.Types.Internal.Object)
   -- | float
+  -- 
+  -- Constraints:
+  -- 
+  -- * Must be a multiple of 1.0e-2
   , dogFloat :: (GHC.Maybe.Maybe GHC.Types.Float)
   -- | int32
   , dogInt32 :: (GHC.Maybe.Maybe GHC.Int.Int32)
   -- | int64
+  -- 
+  -- Constraints:
+  -- 
+  -- * Must be a multiple of 4.0
   , dogInt64 :: (GHC.Maybe.Maybe GHC.Int.Int64)
   -- | integer
   , dogInteger :: (GHC.Maybe.Maybe GHC.Types.Int)

--- a/testing/golden-output/src/OpenAPI/Types/Dog.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Dog.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/Mischling.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Mischling.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/Mischling.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Mischling.hs
@@ -62,12 +62,20 @@ data Mischling = Mischling {
   -- | first_relative
   , mischlingFirst_relative :: (GHC.Maybe.Maybe MischlingFirst_relative)
   -- | float
+  -- 
+  -- Constraints:
+  -- 
+  -- * Must be a multiple of 1.0e-2
   , mischlingFloat :: (GHC.Maybe.Maybe GHC.Types.Float)
   -- | huntssecond
   , mischlingHuntssecond :: (GHC.Maybe.Maybe GHC.Types.Bool)
   -- | int32
   , mischlingInt32 :: (GHC.Maybe.Maybe GHC.Int.Int32)
   -- | int64
+  -- 
+  -- Constraints:
+  -- 
+  -- * Must be a multiple of 4.0
   , mischlingInt64 :: (GHC.Maybe.Maybe GHC.Int.Int64)
   -- | integer
   , mischlingInteger :: (GHC.Maybe.Maybe GHC.Types.Int)

--- a/testing/golden-output/src/OpenAPI/Types/PetByAge.hs
+++ b/testing/golden-output/src/OpenAPI/Types/PetByAge.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/PetByType.hs
+++ b/testing/golden-output/src/OpenAPI/Types/PetByType.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/Test6.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Test6.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/Test7.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Test7.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/Test8.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Test8.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base

--- a/testing/golden-output/src/OpenAPI/Types/Test9.hs
+++ b/testing/golden-output/src/OpenAPI/Types/Test9.hs
@@ -22,7 +22,7 @@ import qualified Data.Functor
 import qualified Data.Maybe
 import qualified Data.Scientific
 import qualified Data.Text
-import qualified Data.Text.Internal
+import qualified Data.Text as Data.Text.Internal
 import qualified Data.Time.Calendar as Data.Time.Calendar.Days
 import qualified Data.Time.LocalTime as Data.Time.LocalTime.Internal.ZonedTime
 import qualified GHC.Base


### PR DESCRIPTION
This PR aims to fix multiple problems:
- The generator should not fail on floating point values in the multipleOf field: https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/issues/94
- Do not import `Data.Text.Internal` directly as it seems to limit backwards compatibility: https://github.com/Haskell-OpenAPI-Code-Generator/Stripe-Haskell-Library/issues/14#issuecomment-1883601831