### PR TITLE
fix: allow content types with additional parameters

### DIFF
--- a/specifications/z_complex_self_made_example.yml
+++ b/specifications/z_complex_self_made_example.yml
@@ -49,7 +49,7 @@ paths:
         default:
           description: Expected response to a valid request
           content:
-            application/json:
+            application/json;charset=utf-8:
               schema:
                 $ref: "#/components/schemas/Dog"
   /pet/noparam:


### PR DESCRIPTION
This is a fix for https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/issues/96