### PR TITLE
fix: use ToJSON instance instead of Show to serialize path parameters

### DIFF
--- a/openapi3-code-generator/src/OpenAPI/Generate/Internal/Util.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Internal/Util.hs
@@ -84,7 +84,6 @@ haskellifyText convertToCamelCase startWithUppercase name =
       replaceReservedWord "where" = "where'"
       replaceReservedWord "Configuration" = "Configuration'"
       replaceReservedWord "MonadHTTP" = "MonadHTTP'"
-      replaceReservedWord "StringifyModel" = "StringifyModel'"
       replaceReservedWord "SecurityScheme" = "SecurityScheme'"
       replaceReservedWord "AnonymousSecurityScheme" = "AnonymousSecurityScheme'"
       replaceReservedWord "JsonByteString" = "JsonByteString'"

--- a/specifications/petstore-running-example.yaml
+++ b/specifications/petstore-running-example.yaml
@@ -563,6 +563,27 @@ paths:
                 type: string
         '400':
           description: No User-Agent header is present
+  "/echo/{path}":
+    get:
+      summary: Echo the path
+      operationId: echoPath
+      parameters:
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+          enum:
+            - test
+            - foo
+            - bar
+      responses:
+        '200':
+          description: The path parameter
+          content:
+            application/json:
+              schema:
+                type: string
   "/nullable-optional/{mode}":
     post:
       summary: Test nullable and optional values

--- a/testing/level3/mock-server/src/Lib.hs
+++ b/testing/level3/mock-server/src/Lib.hs
@@ -34,6 +34,7 @@ type API =
     :<|> "pet" :> "findByStatus" :> QueryParam "status" String :> Get '[JSON] [Pet]
     :<|> "pet" :> ReqBody '[JSON] Pet :> Post '[JSON] NoContent
     :<|> "echo" :> Header "User-Agent" String :> Get '[JSON] String
+    :<|> "echo" :> Capture "path" String :> Get '[JSON] String
     :<|> "nullable-optional" :> Capture "mode" String :> ReqBody '[JSON] Value :> Post '[JSON] Value
 
 startApp :: IO ()
@@ -46,7 +47,7 @@ api :: Proxy API
 api = Proxy
 
 server :: Server API
-server = pure getInventory :<|> findByStatus :<|> addPet :<|> userAgentEcho :<|> checkNullableAndOptional
+server = pure getInventory :<|> findByStatus :<|> addPet :<|> userAgentEcho :<|> pathEcho :<|> checkNullableAndOptional
 
 getInventory :: Value
 getInventory = object ["pet1" .= Number 23, "pet2" .= Number 2]
@@ -70,6 +71,9 @@ addPet _ = throwError err405
 userAgentEcho :: Maybe String -> Handler String
 userAgentEcho (Just userAgent) = pure userAgent
 userAgentEcho Nothing = throwError err400
+
+pathEcho :: String -> Handler String
+pathEcho = pure
 
 checkNullableAndOptional :: String -> Value -> Handler Value
 checkNullableAndOptional "filled" (Object map) = do

--- a/testing/level3/petstore-running-example/src/Lib.hs
+++ b/testing/level3/petstore-running-example/src/Lib.hs
@@ -38,5 +38,8 @@ runEchoUserAgentWithoutUserAgent =
       { configIncludeUserAgent = False
       }
 
+runEchoPath :: MonadHTTP m => EchoPathParametersPath -> m (Response EchoPathResponse)
+runEchoPath = echoPathWithConfiguration defaultConfiguration
+
 runSendAndReceiveNullableAndOptional :: MonadHTTP m => Text -> NullableAndOptionalTest -> m (Response SendAndReceiveNullableAndOptionalResponse)
 runSendAndReceiveNullableAndOptional mode body = sendAndReceiveNullableAndOptionalWithConfiguration defaultConfiguration mode body

--- a/testing/level3/petstore-running-example/test/Spec.hs
+++ b/testing/level3/petstore-running-example/test/Spec.hs
@@ -69,6 +69,23 @@ main =
           getResponseBody response
             `shouldBe` EchoUserAgentResponse400
 
+    describe "runEchoPath" $ do
+      it "returns enum value 'test'" $
+        do
+          response <- runEchoPath EchoPathParametersPathEnumTest
+          getResponseBody response
+            `shouldBe` EchoPathResponse200 "test"
+      it "returns enum value 'foo'" $
+        do
+          response <- runEchoPath EchoPathParametersPathEnumFoo
+          getResponseBody response
+            `shouldBe` EchoPathResponse200 "foo"
+      it "works with custom value" $
+        do
+          response <- runEchoPath $ EchoPathParametersPathTyped "xyz"
+          getResponseBody response
+            `shouldBe` EchoPathResponse200 "xyz"
+
     describe "runSendAndReceiveNullableAndOptional" $ do
       it "should work with filled objects" $ do
         response <-


### PR DESCRIPTION
Fix for https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/issues/99