### PR TITLE
Use NonEmpty for arrays that specify minItems > 0

### DIFF
--- a/openapi3-code-generator/src/OpenAPI/Generate/Model.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Model.hs
@@ -23,6 +23,7 @@ import qualified Data.Bifunctor as BF
 import qualified Data.Either as E
 import qualified Data.Int as Int
 import qualified Data.List as List
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Scientific as Scientific
@@ -560,7 +561,10 @@ defineArrayModelForSchema strategy schemaName schema = do
       Nothing -> do
         OAM.logWarning "Array type was defined without a items schema and therefore cannot be defined correctly"
         pure ([t|Aeson.Object|], (emptyDoc, Set.empty))
-  let arrayType = appT listT type'
+  let arrayType =
+        case OAS.schemaObjectMinItems schema of
+          Just w | w > 0 -> appT [t|NonEmpty|] type'
+          _ -> appT listT type'
   schemaName' <- haskellifyNameM True schemaName
   OAM.logTrace $ "Define as list named '" <> T.pack (nameBase schemaName') <> "'"
   path <- getCurrentPathEscaped

--- a/specifications/z_complex_self_made_example.yml
+++ b/specifications/z_complex_self_made_example.yml
@@ -366,6 +366,11 @@ components:
       type: string
       enum:
         - xxx
+    Test10:
+      type: array
+      items:
+        type: string
+      minItems: 1
     CoverType:
       type: object
       properties:
@@ -382,6 +387,7 @@ components:
             - $ref: '#/components/schemas/Test7'
             - $ref: '#/components/schemas/Test8'
             - $ref: '#/components/schemas/Test9'
+            - $ref: '#/components/schemas/Test10'
   parameters:
     PetParameters:
       name: petId

--- a/testing/golden-output/src/OpenAPI/TypeAlias.hs
+++ b/testing/golden-output/src/OpenAPI/TypeAlias.hs
@@ -54,6 +54,11 @@ type Test3 = Data.Aeson.Types.Internal.Object
 -- 
 type Test2 = [Data.Text.Internal.Text]
 
+-- | Defines an alias for the schema located at @components.schemas.Test10@ in the specification.
+-- 
+-- 
+type Test10 = GHC.Base.NonEmpty Data.Text.Internal.Text
+
 -- | Defines an alias for the schema located at @components.schemas.Test@ in the specification.
 -- 
 -- 

--- a/testing/golden-output/src/OpenAPI/Types/CoverType.hs
+++ b/testing/golden-output/src/OpenAPI/Types/CoverType.hs
@@ -70,6 +70,7 @@ data CoverTypeCoverVariants =
   | CoverTypeCoverTest7 Test7
   | CoverTypeCoverTest8 Test8
   | CoverTypeCoverTest9 Test9
+  | CoverTypeCoverTest10 Test10
   deriving (GHC.Show.Show, GHC.Classes.Eq)
 instance Data.Aeson.Types.ToJSON.ToJSON CoverTypeCoverVariants
     where {toJSON (CoverTypeCoverPetByAge a) = Data.Aeson.Types.ToJSON.toJSON a;
@@ -82,8 +83,9 @@ instance Data.Aeson.Types.ToJSON.ToJSON CoverTypeCoverVariants
            toJSON (CoverTypeCoverTest6 a) = Data.Aeson.Types.ToJSON.toJSON a;
            toJSON (CoverTypeCoverTest7 a) = Data.Aeson.Types.ToJSON.toJSON a;
            toJSON (CoverTypeCoverTest8 a) = Data.Aeson.Types.ToJSON.toJSON a;
-           toJSON (CoverTypeCoverTest9 a) = Data.Aeson.Types.ToJSON.toJSON a}
+           toJSON (CoverTypeCoverTest9 a) = Data.Aeson.Types.ToJSON.toJSON a;
+           toJSON (CoverTypeCoverTest10 a) = Data.Aeson.Types.ToJSON.toJSON a}
 instance Data.Aeson.Types.FromJSON.FromJSON CoverTypeCoverVariants
-    where {parseJSON val = case (CoverTypeCoverPetByAge Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverMischling Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest2 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest3 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest4 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest5 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest6 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest7 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest8 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest9 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> Data.Aeson.Types.Internal.Error "No variant matched")))))))))) of
+    where {parseJSON val = case (CoverTypeCoverPetByAge Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverMischling Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest2 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest3 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest4 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest5 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest6 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest7 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest8 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest9 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> ((CoverTypeCoverTest10 Data.Functor.<$> Data.Aeson.Types.FromJSON.fromJSON val) GHC.Base.<|> Data.Aeson.Types.Internal.Error "No variant matched"))))))))))) of
                            {Data.Aeson.Types.Internal.Success a -> GHC.Base.pure a;
                             Data.Aeson.Types.Internal.Error a -> Control.Monad.Fail.fail a}}


### PR DESCRIPTION
### [Use NonEmpty for arrays that specify minItems > 0](https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/pull/102/commits/a89d27d6892b46abab25cd84aee9eafeacb63981)
[a89d27d](https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/pull/102/commits/a89d27d6892b46abab25cd84aee9eafeacb63981)

### [Exercise minItems/NonEmpty in golden tests](https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/pull/102/commits/325816ac5e445d32444f13647dc5b3abdef1ef9a)
[325816a](https://github.com/Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator/pull/102/commits/325816ac5e445d32444f13647dc5b3abdef1ef9a)