### PR TITLE
qualify aeson import in generated hs-boot files

### DIFF
--- a/example/generatedCode/src/OpenAPI/Types/ApiResponse.hs-boot
+++ b/example/generatedCode/src/OpenAPI/Types/ApiResponse.hs-boot
@@ -1,9 +1,8 @@
 module OpenAPI.Types.ApiResponse where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data ApiResponse
 instance Show ApiResponse
 instance Eq ApiResponse
-instance FromJSON ApiResponse
-instance ToJSON ApiResponse
+instance Data.Aeson.FromJSON ApiResponse
+instance Data.Aeson.ToJSON ApiResponse

--- a/example/generatedCode/src/OpenAPI/Types/Category.hs-boot
+++ b/example/generatedCode/src/OpenAPI/Types/Category.hs-boot
@@ -1,9 +1,8 @@
 module OpenAPI.Types.Category where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Category
 instance Show Category
 instance Eq Category
-instance FromJSON Category
-instance ToJSON Category
+instance Data.Aeson.FromJSON Category
+instance Data.Aeson.ToJSON Category

--- a/example/generatedCode/src/OpenAPI/Types/Order.hs-boot
+++ b/example/generatedCode/src/OpenAPI/Types/Order.hs-boot
@@ -1,14 +1,13 @@
 module OpenAPI.Types.Order where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Order
 instance Show Order
 instance Eq Order
-instance FromJSON Order
-instance ToJSON Order
+instance Data.Aeson.FromJSON Order
+instance Data.Aeson.ToJSON Order
 data OrderStatus
 instance Show OrderStatus
 instance Eq OrderStatus
-instance FromJSON OrderStatus
-instance ToJSON OrderStatus
+instance Data.Aeson.FromJSON OrderStatus
+instance Data.Aeson.ToJSON OrderStatus

--- a/example/generatedCode/src/OpenAPI/Types/Pet.hs-boot
+++ b/example/generatedCode/src/OpenAPI/Types/Pet.hs-boot
@@ -1,14 +1,13 @@
 module OpenAPI.Types.Pet where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Pet
 instance Show Pet
 instance Eq Pet
-instance FromJSON Pet
-instance ToJSON Pet
+instance Data.Aeson.FromJSON Pet
+instance Data.Aeson.ToJSON Pet
 data PetStatus
 instance Show PetStatus
 instance Eq PetStatus
-instance FromJSON PetStatus
-instance ToJSON PetStatus
+instance Data.Aeson.FromJSON PetStatus
+instance Data.Aeson.ToJSON PetStatus

--- a/example/generatedCode/src/OpenAPI/Types/Tag.hs-boot
+++ b/example/generatedCode/src/OpenAPI/Types/Tag.hs-boot
@@ -1,9 +1,8 @@
 module OpenAPI.Types.Tag where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Tag
 instance Show Tag
 instance Eq Tag
-instance FromJSON Tag
-instance ToJSON Tag
+instance Data.Aeson.FromJSON Tag
+instance Data.Aeson.ToJSON Tag

--- a/example/generatedCode/src/OpenAPI/Types/User.hs-boot
+++ b/example/generatedCode/src/OpenAPI/Types/User.hs-boot
@@ -1,9 +1,8 @@
 module OpenAPI.Types.User where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data User
 instance Show User
 instance Eq User
-instance FromJSON User
-instance ToJSON User
+instance Data.Aeson.FromJSON User
+instance Data.Aeson.ToJSON User

--- a/openapi3-code-generator/src/OpenAPI/Generate/IO.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/IO.hs
@@ -160,8 +160,7 @@ getHsBootFiles settings modelModules =
             . ( \xs -> case xs of
                   x : xs' ->
                     x
-                      : "import Data.Aeson"
-                      : "import qualified Data.Aeson as Data.Aeson.Types.Internal"
+                      : "import qualified Data.Aeson"
                       : "import qualified " <> T.pack moduleName <> ".Common"
                       : xs'
                   _ -> xs
@@ -173,8 +172,8 @@ getHsBootFiles settings modelModules =
                           [ l,
                             "instance Show" <> suffix,
                             "instance Eq" <> suffix,
-                            "instance FromJSON" <> suffix,
-                            "instance ToJSON" <> suffix
+                            "instance Data.Aeson.FromJSON" <> suffix,
+                            "instance Data.Aeson.ToJSON" <> suffix
                           ]
                       )
                       $ T.stripPrefix "data" l

--- a/testing/golden-output/src/OpenAPI/Types/Cat.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/Cat.hs-boot
@@ -1,19 +1,18 @@
 module OpenAPI.Types.Cat where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Cat
 instance Show Cat
 instance Eq Cat
-instance FromJSON Cat
-instance ToJSON Cat
+instance Data.Aeson.FromJSON Cat
+instance Data.Aeson.ToJSON Cat
 data CatAnother_relativeVariants
 instance Show CatAnother_relativeVariants
 instance Eq CatAnother_relativeVariants
-instance FromJSON CatAnother_relativeVariants
-instance ToJSON CatAnother_relativeVariants
+instance Data.Aeson.FromJSON CatAnother_relativeVariants
+instance Data.Aeson.ToJSON CatAnother_relativeVariants
 data CatRelativeVariants
 instance Show CatRelativeVariants
 instance Eq CatRelativeVariants
-instance FromJSON CatRelativeVariants
-instance ToJSON CatRelativeVariants
+instance Data.Aeson.FromJSON CatRelativeVariants
+instance Data.Aeson.ToJSON CatRelativeVariants

--- a/testing/golden-output/src/OpenAPI/Types/CoverType.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/CoverType.hs-boot
@@ -1,14 +1,13 @@
 module OpenAPI.Types.CoverType where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data CoverType
 instance Show CoverType
 instance Eq CoverType
-instance FromJSON CoverType
-instance ToJSON CoverType
+instance Data.Aeson.FromJSON CoverType
+instance Data.Aeson.ToJSON CoverType
 data CoverTypeCoverVariants
 instance Show CoverTypeCoverVariants
 instance Eq CoverTypeCoverVariants
-instance FromJSON CoverTypeCoverVariants
-instance ToJSON CoverTypeCoverVariants
+instance Data.Aeson.FromJSON CoverTypeCoverVariants
+instance Data.Aeson.ToJSON CoverTypeCoverVariants

--- a/testing/golden-output/src/OpenAPI/Types/Dog.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/Dog.hs-boot
@@ -1,14 +1,13 @@
 module OpenAPI.Types.Dog where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Dog
 instance Show Dog
 instance Eq Dog
-instance FromJSON Dog
-instance ToJSON Dog
+instance Data.Aeson.FromJSON Dog
+instance Data.Aeson.ToJSON Dog
 data DogBreed
 instance Show DogBreed
 instance Eq DogBreed
-instance FromJSON DogBreed
-instance ToJSON DogBreed
+instance Data.Aeson.FromJSON DogBreed
+instance Data.Aeson.ToJSON DogBreed

--- a/testing/golden-output/src/OpenAPI/Types/Mischling.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/Mischling.hs-boot
@@ -1,49 +1,48 @@
 module OpenAPI.Types.Mischling where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Mischling
 instance Show Mischling
 instance Eq Mischling
-instance FromJSON Mischling
-instance ToJSON Mischling
+instance Data.Aeson.FromJSON Mischling
+instance Data.Aeson.ToJSON Mischling
 data MischlingAnother_relativeOneOf5
 instance Show MischlingAnother_relativeOneOf5
 instance Eq MischlingAnother_relativeOneOf5
-instance FromJSON MischlingAnother_relativeOneOf5
-instance ToJSON MischlingAnother_relativeOneOf5
+instance Data.Aeson.FromJSON MischlingAnother_relativeOneOf5
+instance Data.Aeson.ToJSON MischlingAnother_relativeOneOf5
 data MischlingAnother_relativeVariants
 instance Show MischlingAnother_relativeVariants
 instance Eq MischlingAnother_relativeVariants
-instance FromJSON MischlingAnother_relativeVariants
-instance ToJSON MischlingAnother_relativeVariants
+instance Data.Aeson.FromJSON MischlingAnother_relativeVariants
+instance Data.Aeson.ToJSON MischlingAnother_relativeVariants
 data MischlingBreed
 instance Show MischlingBreed
 instance Eq MischlingBreed
-instance FromJSON MischlingBreed
-instance ToJSON MischlingBreed
+instance Data.Aeson.FromJSON MischlingBreed
+instance Data.Aeson.ToJSON MischlingBreed
 data MischlingFirst_relative
 instance Show MischlingFirst_relative
 instance Eq MischlingFirst_relative
-instance FromJSON MischlingFirst_relative
-instance ToJSON MischlingFirst_relative
+instance Data.Aeson.FromJSON MischlingFirst_relative
+instance Data.Aeson.ToJSON MischlingFirst_relative
 data MischlingFirst_relativeAnother_relativeVariants
 instance Show MischlingFirst_relativeAnother_relativeVariants
 instance Eq MischlingFirst_relativeAnother_relativeVariants
-instance FromJSON MischlingFirst_relativeAnother_relativeVariants
-instance ToJSON MischlingFirst_relativeAnother_relativeVariants
+instance Data.Aeson.FromJSON MischlingFirst_relativeAnother_relativeVariants
+instance Data.Aeson.ToJSON MischlingFirst_relativeAnother_relativeVariants
 data MischlingFirst_relativePet_type
 instance Show MischlingFirst_relativePet_type
 instance Eq MischlingFirst_relativePet_type
-instance FromJSON MischlingFirst_relativePet_type
-instance ToJSON MischlingFirst_relativePet_type
+instance Data.Aeson.FromJSON MischlingFirst_relativePet_type
+instance Data.Aeson.ToJSON MischlingFirst_relativePet_type
 data MischlingFirst_relativeRelativeVariants
 instance Show MischlingFirst_relativeRelativeVariants
 instance Eq MischlingFirst_relativeRelativeVariants
-instance FromJSON MischlingFirst_relativeRelativeVariants
-instance ToJSON MischlingFirst_relativeRelativeVariants
+instance Data.Aeson.FromJSON MischlingFirst_relativeRelativeVariants
+instance Data.Aeson.ToJSON MischlingFirst_relativeRelativeVariants
 data MischlingRelativeVariants
 instance Show MischlingRelativeVariants
 instance Eq MischlingRelativeVariants
-instance FromJSON MischlingRelativeVariants
-instance ToJSON MischlingRelativeVariants
+instance Data.Aeson.FromJSON MischlingRelativeVariants
+instance Data.Aeson.ToJSON MischlingRelativeVariants

--- a/testing/golden-output/src/OpenAPI/Types/PetByAge.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/PetByAge.hs-boot
@@ -1,44 +1,43 @@
 module OpenAPI.Types.PetByAge where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data PetByAge
 instance Show PetByAge
 instance Eq PetByAge
-instance FromJSON PetByAge
-instance ToJSON PetByAge
+instance Data.Aeson.FromJSON PetByAge
+instance Data.Aeson.ToJSON PetByAge
 data PetByAgeAnother_relativeOneOf5
 instance Show PetByAgeAnother_relativeOneOf5
 instance Eq PetByAgeAnother_relativeOneOf5
-instance FromJSON PetByAgeAnother_relativeOneOf5
-instance ToJSON PetByAgeAnother_relativeOneOf5
+instance Data.Aeson.FromJSON PetByAgeAnother_relativeOneOf5
+instance Data.Aeson.ToJSON PetByAgeAnother_relativeOneOf5
 data PetByAgeAnother_relativeVariants
 instance Show PetByAgeAnother_relativeVariants
 instance Eq PetByAgeAnother_relativeVariants
-instance FromJSON PetByAgeAnother_relativeVariants
-instance ToJSON PetByAgeAnother_relativeVariants
+instance Data.Aeson.FromJSON PetByAgeAnother_relativeVariants
+instance Data.Aeson.ToJSON PetByAgeAnother_relativeVariants
 data PetByAgeFirst_relative
 instance Show PetByAgeFirst_relative
 instance Eq PetByAgeFirst_relative
-instance FromJSON PetByAgeFirst_relative
-instance ToJSON PetByAgeFirst_relative
+instance Data.Aeson.FromJSON PetByAgeFirst_relative
+instance Data.Aeson.ToJSON PetByAgeFirst_relative
 data PetByAgeFirst_relativeAnother_relativeVariants
 instance Show PetByAgeFirst_relativeAnother_relativeVariants
 instance Eq PetByAgeFirst_relativeAnother_relativeVariants
-instance FromJSON PetByAgeFirst_relativeAnother_relativeVariants
-instance ToJSON PetByAgeFirst_relativeAnother_relativeVariants
+instance Data.Aeson.FromJSON PetByAgeFirst_relativeAnother_relativeVariants
+instance Data.Aeson.ToJSON PetByAgeFirst_relativeAnother_relativeVariants
 data PetByAgeFirst_relativePet_type
 instance Show PetByAgeFirst_relativePet_type
 instance Eq PetByAgeFirst_relativePet_type
-instance FromJSON PetByAgeFirst_relativePet_type
-instance ToJSON PetByAgeFirst_relativePet_type
+instance Data.Aeson.FromJSON PetByAgeFirst_relativePet_type
+instance Data.Aeson.ToJSON PetByAgeFirst_relativePet_type
 data PetByAgeFirst_relativeRelativeVariants
 instance Show PetByAgeFirst_relativeRelativeVariants
 instance Eq PetByAgeFirst_relativeRelativeVariants
-instance FromJSON PetByAgeFirst_relativeRelativeVariants
-instance ToJSON PetByAgeFirst_relativeRelativeVariants
+instance Data.Aeson.FromJSON PetByAgeFirst_relativeRelativeVariants
+instance Data.Aeson.ToJSON PetByAgeFirst_relativeRelativeVariants
 data PetByAgeRelativeVariants
 instance Show PetByAgeRelativeVariants
 instance Eq PetByAgeRelativeVariants
-instance FromJSON PetByAgeRelativeVariants
-instance ToJSON PetByAgeRelativeVariants
+instance Data.Aeson.FromJSON PetByAgeRelativeVariants
+instance Data.Aeson.ToJSON PetByAgeRelativeVariants

--- a/testing/golden-output/src/OpenAPI/Types/PetByType.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/PetByType.hs-boot
@@ -1,14 +1,13 @@
 module OpenAPI.Types.PetByType where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data PetByType
 instance Show PetByType
 instance Eq PetByType
-instance FromJSON PetByType
-instance ToJSON PetByType
+instance Data.Aeson.FromJSON PetByType
+instance Data.Aeson.ToJSON PetByType
 data PetByTypePet_type
 instance Show PetByTypePet_type
 instance Eq PetByTypePet_type
-instance FromJSON PetByTypePet_type
-instance ToJSON PetByTypePet_type
+instance Data.Aeson.FromJSON PetByTypePet_type
+instance Data.Aeson.ToJSON PetByTypePet_type

--- a/testing/golden-output/src/OpenAPI/Types/Test6.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/Test6.hs-boot
@@ -1,9 +1,8 @@
 module OpenAPI.Types.Test6 where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Test6
 instance Show Test6
 instance Eq Test6
-instance FromJSON Test6
-instance ToJSON Test6
+instance Data.Aeson.FromJSON Test6
+instance Data.Aeson.ToJSON Test6

--- a/testing/golden-output/src/OpenAPI/Types/Test7.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/Test7.hs-boot
@@ -1,10 +1,9 @@
 module OpenAPI.Types.Test7 where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Test7Item
 instance Show Test7Item
 instance Eq Test7Item
-instance FromJSON Test7Item
-instance ToJSON Test7Item
+instance Data.Aeson.FromJSON Test7Item
+instance Data.Aeson.ToJSON Test7Item
 type Test7 = [Test7Item]

--- a/testing/golden-output/src/OpenAPI/Types/Test8.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/Test8.hs-boot
@@ -1,10 +1,9 @@
 module OpenAPI.Types.Test8 where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Test8NonNullable
 instance Show Test8NonNullable
 instance Eq Test8NonNullable
-instance FromJSON Test8NonNullable
-instance ToJSON Test8NonNullable
+instance Data.Aeson.FromJSON Test8NonNullable
+instance Data.Aeson.ToJSON Test8NonNullable
 type Test8 = OpenAPI.Common.Nullable Test8NonNullable

--- a/testing/golden-output/src/OpenAPI/Types/Test9.hs-boot
+++ b/testing/golden-output/src/OpenAPI/Types/Test9.hs-boot
@@ -1,9 +1,8 @@
 module OpenAPI.Types.Test9 where
-import Data.Aeson
-import qualified Data.Aeson as Data.Aeson.Types.Internal
+import qualified Data.Aeson
 import qualified OpenAPI.Common
 data Test9
 instance Show Test9
 instance Eq Test9
-instance FromJSON Test9
-instance ToJSON Test9
+instance Data.Aeson.FromJSON Test9
+instance Data.Aeson.ToJSON Test9


### PR DESCRIPTION
I believe this fixes #107.

I also removed the line `import qualified Data.Aeson as Data.Aeson.Types.Internal`, and it does not seem to be needed.