### PR TITLE
Vital Fixes

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -11,7 +11,7 @@ let
         extraFlags = extraFlags;
       };
     };
-  goldenTestCode = generateCode { fileName = "z_complex_self_made_example.yml"; };
+  goldenTestCode = generateCode { fileName = "z_complex_self_made_example.yml"; extraFlags = [ "--output-all-schemas" ]; };
   exampleGeneratedCode = generateCode { fileName = "petstore.yaml"; };
   codeForSpecsLevelOne = [
     (generateCode { fileName = "google-payment.json"; })

--- a/openapi3-code-generator/src/OpenAPI/Generate/Main.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Main.hs
@@ -80,8 +80,9 @@ defineModels moduleName spec operationDependencies =
           warnAboutUnknownWhiteListedOrOpaqueSchemas schemaDefinitions
           models <- mapM (uncurry Model.defineModelForSchema) schemaDefinitions
           whiteListedSchemas <- OAM.getSetting OAO.settingWhiteListedSchemas
+          outputAllSchemas <- OAM.getSetting OAO.settingOutputAllSchemas
           let dependencies = Set.union operationDependencies $ Set.fromList $ fmap transformToModuleName whiteListedSchemas
-          pure $ Dep.getModelModulesFromModelsWithDependencies moduleName dependencies models
+          pure $ Dep.getModelModulesFromModelsWithDependencies moduleName dependencies models outputAllSchemas
 
 -- | Defines all supported security schemes from the 'OAT.OpenApiSpecification'.
 defineSecuritySchemes :: String -> OAT.OpenApiSpecification -> OAM.Generator (Q Doc)

--- a/openapi3-code-generator/src/OpenAPI/Generate/Main.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Main.hs
@@ -82,7 +82,7 @@ defineModels moduleName spec operationDependencies =
           whiteListedSchemas <- OAM.getSetting OAO.settingWhiteListedSchemas
           outputAllSchemas <- OAM.getSetting OAO.settingOutputAllSchemas
           let dependencies = Set.union operationDependencies $ Set.fromList $ fmap transformToModuleName whiteListedSchemas
-          pure $ Dep.getModelModulesFromModelsWithDependencies moduleName dependencies models outputAllSchemas
+          pure $ Dep.getModelModulesFromModelsWithDependencies moduleName dependencies outputAllSchemas models
 
 -- | Defines all supported security schemes from the 'OAT.OpenApiSpecification'.
 defineSecuritySchemes :: String -> OAT.OpenApiSpecification -> OAM.Generator (Q Doc)

--- a/openapi3-code-generator/src/OpenAPI/Generate/Model.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/Model.hs
@@ -128,7 +128,8 @@ defineModelForSchemaNamedWithTypeAliasStrategy strategy schemaName schema =
     OAT.Reference reference -> do
       refName <- haskellifyNameM True $ getSchemaNameFromReference reference
       OAM.logTrace $ "Encountered reference '" <> reference <> "' which references the type '" <> T.pack (nameBase refName) <> "'"
-      pure (varT refName, (emptyDoc, transformReferenceToDependency reference))
+      createAlias schemaName "" strategy $
+        pure (varT refName, (emptyDoc, transformReferenceToDependency reference))
 
 getSchemaNameFromReference :: Text -> Text
 getSchemaNameFromReference = T.replace "#/components/schemas/" ""

--- a/openapi3-code-generator/src/OpenAPI/Generate/ModelDependencies.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/ModelDependencies.hs
@@ -38,9 +38,12 @@ typesModule = "Types"
 
 -- | Analyzes the dependencies of the provided models and splits them into modules.
 -- All models which would form an own module but only consist of a type alias are put in a module named by 'Doc.typeAliasModule'.
-getModelModulesFromModelsWithDependencies :: String -> Models -> [ModelWithDependencies] -> Q [ModuleDefinition]
-getModelModulesFromModelsWithDependencies mainModuleName operationAndWhiteListDependencies models = do
-  let modelsToGenerate = filterRequiredModels operationAndWhiteListDependencies models
+getModelModulesFromModelsWithDependencies :: String -> Models -> [ModelWithDependencies] -> Bool -> Q [ModuleDefinition]
+getModelModulesFromModelsWithDependencies mainModuleName operationAndWhiteListDependencies models outputAllSchemas = do
+  let modelsToGenerate =
+        if outputAllSchemas
+          then models
+          else filterRequiredModels operationAndWhiteListDependencies models
       prependTypesModule = ((typesModule <> ".") <>) . T.unpack
       prependMainModule = ((mainModuleName <> ".") <>)
   modelsWithResolvedContent <-

--- a/openapi3-code-generator/src/OpenAPI/Generate/ModelDependencies.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/ModelDependencies.hs
@@ -38,8 +38,8 @@ typesModule = "Types"
 
 -- | Analyzes the dependencies of the provided models and splits them into modules.
 -- All models which would form an own module but only consist of a type alias are put in a module named by 'Doc.typeAliasModule'.
-getModelModulesFromModelsWithDependencies :: String -> Models -> [ModelWithDependencies] -> Bool -> Q [ModuleDefinition]
-getModelModulesFromModelsWithDependencies mainModuleName operationAndWhiteListDependencies models outputAllSchemas = do
+getModelModulesFromModelsWithDependencies :: String -> Models -> Bool -> [ModelWithDependencies] -> Q [ModuleDefinition]
+getModelModulesFromModelsWithDependencies mainModuleName operationAndWhiteListDependencies outputAllSchemas models = do
   let modelsToGenerate =
         if outputAllSchemas
           then models

--- a/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
@@ -101,6 +101,8 @@ data Settings = Settings
     -- which need to be generated.
     -- For all other schemas only a type alias to 'Aeson.Value' is created.
     settingWhiteListedSchemas :: ![Text],
+    -- | Output all schemas.
+    settingOutputAllSchemas :: !Bool,
     -- | In OpenAPI 3, fixed values can be defined as an enum with only one allowed value.
     -- If such a constant value is encountered as a required property of an object,
     -- the generator excludes this property by default ("exclude" strategy) and
@@ -153,6 +155,7 @@ combineToSettings Flags {..} mConf configurationFilePath = do
       settingOperationsToGenerate = fromMaybe [] $ flagOperationsToGenerate <|> mc configOperationsToGenerate
       settingOpaqueSchemas = fromMaybe [] $ flagOpaqueSchemas <|> mc configOpaqueSchemas
       settingWhiteListedSchemas = fromMaybe [] $ flagWhiteListedSchemas <|> mc configWhiteListedSchemas
+      settingOutputAllSchemas = fromMaybe False $ flagOutputAllSchemas <|> mc configOutputAllSchemas
       settingFixedValueStrategy = fromMaybe FixedValueStrategyExclude $ flagFixedValueStrategy <|> mc configFixedValueStrategy
 
   pure Settings {..}

--- a/openapi3-code-generator/src/OpenAPI/Generate/OptParse/Configuration.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/OptParse/Configuration.hs
@@ -48,6 +48,7 @@ data Configuration = Configuration
     configOperationsToGenerate :: !(Maybe [Text]),
     configOpaqueSchemas :: !(Maybe [Text]),
     configWhiteListedSchemas :: !(Maybe [Text]),
+    configOutputAllSchemas :: !(Maybe Bool),
     configFixedValueStrategy :: !(Maybe FixedValueStrategy)
   }
   deriving stock (Show, Eq)
@@ -88,6 +89,7 @@ instance HasCodec Configuration where
         <*> optionalField "operationsToGenerate" "If not all operations should be generated, this option can be used to specify all of them which should be generated. The value has to correspond to the value in the 'operationId' field in the OpenAPI 3 specification." .= configOperationsToGenerate
         <*> optionalField "opaqueSchemas" "A list of schema names (exactly as they are named in the components.schemas section of the corresponding OpenAPI 3 specification) which are not further investigated while generating code from the specification. Only a type alias to 'Aeson.Value' is created for these schemas." .= configOpaqueSchemas
         <*> optionalField "whiteListedSchemas" "A list of schema names (exactly as they are named in the components.schemas section of the corresponding OpenAPI 3 specification) which need to be generated. For all other schemas only a type alias to 'Aeson.Value' is created." .= configWhiteListedSchemas
+        <*> optionalField "outputAllSchemas" "Output all component schemas" .= configOutputAllSchemas
         <*> optionalField "fixedValueStrategy" "In OpenAPI 3, fixed values can be defined as an enum with only one allowed value. If such a constant value is encountered as a required property of an object, the generator excludes this property by default ('exclude' strategy) and adds the value in the 'ToJSON' instance and expects the value to be there in the 'FromJSON' instance. This setting allows to change this behavior by including all fixed value fields instead ('include' strategy), i.e. just not trying to do anything smart." .= configFixedValueStrategy
 
 getConfiguration :: Text -> IO (Maybe Configuration)

--- a/openapi3-code-generator/src/OpenAPI/Generate/OptParse/Flags.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/OptParse/Flags.hs
@@ -45,6 +45,7 @@ data Flags = Flags
     flagOperationsToGenerate :: !(Maybe [Text]),
     flagOpaqueSchemas :: !(Maybe [Text]),
     flagWhiteListedSchemas :: !(Maybe [Text]),
+    flagOutputAllSchemas :: !(Maybe Bool),
     flagFixedValueStrategy :: !(Maybe FixedValueStrategy)
   }
   deriving (Show, Eq)
@@ -84,6 +85,7 @@ parseFlags =
     <*> parseFlagOperationsToGenerate
     <*> parseFlagOpaqueSchemas
     <*> parseFlagWhiteListedSchemas
+    <*> parseFlagOutputAllSchemas
     <*> parseFlagFixedValueStrategy
 
 parseFlagConfiguration :: Parser (Maybe Text)
@@ -366,6 +368,10 @@ parseFlagWhiteListedSchemas =
             help "A list of schema names (exactly as they are named in the components.schemas section of the corresponding OpenAPI 3 specification) which need to be generated. For all other schemas only a type alias to 'Aeson.Value' is created.",
             long "white-listed-schema"
           ]
+
+parseFlagOutputAllSchemas :: Parser (Maybe Bool)
+parseFlagOutputAllSchemas =
+  booleanFlag "Output all component schemas" "output-all-schemas" Nothing
 
 parseFlagFixedValueStrategy :: Parser (Maybe FixedValueStrategy)
 parseFlagFixedValueStrategy =

--- a/openapi3-code-generator/test/OpenAPI/Generate/ModelDependenciesSpec.hs
+++ b/openapi3-code-generator/test/OpenAPI/Generate/ModelDependenciesSpec.hs
@@ -14,7 +14,7 @@ import Test.Hspec
 spec :: Spec
 spec =
   describe "getModelModulesFromModelsWithDependencies" $ do
-    let sut = getModelModulesFromModelsWithDependencies "OpenAPI" (Set.fromList ["A", "B", "C", "D", "E", "F", "G"])
+    let sut = getModelModulesFromModelsWithDependencies "OpenAPI" (Set.fromList ["A", "B", "C", "D", "E", "F", "G"]) False
         t = pure . text
     it "should split string into pieces" $ do
       result <-

--- a/specifications/z_complex_self_made_example.yml
+++ b/specifications/z_complex_self_made_example.yml
@@ -393,6 +393,8 @@ components:
             - $ref: '#/components/schemas/Test9'
             - $ref: '#/components/schemas/Test10'
             - $ref: '#/components/schemas/Value'
+    CatWrapper:
+      $ref: '#/components/schemas/Cat'
   parameters:
     PetParameters:
       name: petId

--- a/testing/golden-output/src/OpenAPI/TypeAlias.hs
+++ b/testing/golden-output/src/OpenAPI/TypeAlias.hs
@@ -31,6 +31,7 @@ import qualified GHC.Int
 import qualified GHC.Show
 import qualified GHC.Types
 import qualified OpenAPI.Common
+import {-# SOURCE #-} OpenAPI.Types.Cat
 import {-# SOURCE #-} OpenAPI.Types.Dog
 
 
@@ -63,3 +64,8 @@ type Test10 = GHC.Base.NonEmpty Data.Text.Internal.Text
 -- 
 -- 
 type Test = Data.Text.Internal.Text
+
+-- | Defines an alias for the schema located at @components.schemas.CatWrapper@ in the specification.
+-- 
+-- 
+type CatWrapper = Cat


### PR DESCRIPTION
A couple things I changed here:

1. I added an option to output all schemas. We have types that come through in a Websocket which I added to the spec. The default behavior is to not include schemas unless they are part of an operation.
2. Newtypes, which wrap a single ref, weren't getting type aliased correctly. I think I did that now.
```yaml
components:
  schemas:
    NewtypeFoo:
      description: Wrapper for a foo.
      $ref: '#/components/schemas/InnerFoo'
```