### PR TITLE
Compound top level module name

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -26,6 +26,7 @@ let
     (generateCode { fileName = "spot_api.yml"; extraFlags = [ "--opaque-schema=\"aggTrade\"" ]; })
     (generateCode { fileName = "uber.json"; })
     (generateCode { fileName = "z_complex_self_made_example.yml"; })
+    (generateCode { fileName = "petstore.yaml"; extraFlags = [ "--module-name=\"Petstore.API\"" ]; })
   ];
   codeForSpecsLevelTwo = [
     (generateCode { fileName = "official-petstore.yaml"; })

--- a/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/OptParse.hs
@@ -7,6 +7,7 @@
 module OpenAPI.Generate.OptParse
   ( Settings (..),
     getSettings,
+    module OAT,
   )
 where
 
@@ -19,7 +20,7 @@ import qualified Data.Text as T
 import qualified OpenAPI.Generate.Log as OAL
 import OpenAPI.Generate.OptParse.Configuration
 import OpenAPI.Generate.OptParse.Flags
-import OpenAPI.Generate.OptParse.Types
+import OpenAPI.Generate.OptParse.Types as OAT
 import Options.Applicative
 import Options.Applicative.Help (string)
 import Path
@@ -42,7 +43,7 @@ data Settings = Settings
     -- | Name of the stack project
     settingPackageName :: !Text,
     -- | Name of the module
-    settingModuleName :: !Text,
+    settingModuleName :: !ModuleName,
     -- | The minimum log level to output
     settingLogLevel :: !OAL.LogSeverity,
     -- | Overwrite output directory without question
@@ -127,7 +128,7 @@ combineToSettings Flags {..} mConf configurationFilePath = do
   let settingOpenApiSpecification = fromMaybe "openapi-specification.yml" $ flagOpenApiSpecification <|> mConfigOpenApiSpecification
       settingOutputDir = fromMaybe "out" $ flagOutputDir <|> mConfigOutputDir
       settingPackageName = fromMaybe "openapi" $ flagPackageName <|> mc configPackageName
-      settingModuleName = fromMaybe "OpenAPI" $ flagModuleName <|> mc configModuleName
+      settingModuleName = mkModuleName . T.unpack $ fromMaybe "OpenAPI" (flagModuleName <|> mc configModuleName)
       settingLogLevel = fromMaybe OAL.InfoSeverity $ flagLogLevel <|> mc configLogLevel
       settingForce = fromMaybe False $ flagForce <|> mc configForce
       settingIncremental = fromMaybe False $ flagIncremental <|> mc configIncremental

--- a/openapi3-code-generator/src/OpenAPI/Generate/OptParse/Types.hs
+++ b/openapi3-code-generator/src/OpenAPI/Generate/OptParse/Types.hs
@@ -1,9 +1,60 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module OpenAPI.Generate.OptParse.Types
   ( FixedValueStrategy (..),
+    ModuleName,
+    ModulePathInfo,
+    mkModuleName,
+    getModuleName,
+    mkModulePathInfo,
+    getModuleInfoPath,
+    getModuleInfoDir,
   )
 where
 
 import Autodocodec
+import qualified Data.Maybe as Maybe
+import qualified Data.Text as T
+import System.FilePath ((</>))
+
+newtype ModuleName = ModuleName String
+  deriving (Show, Eq)
+
+newtype ModulePathInfo = ModulePathInfo (Maybe FilePath, FilePath)
+
+mkModuleName :: String -> ModuleName
+mkModuleName = ModuleName
+
+getModuleName :: ModuleName -> String
+getModuleName (ModuleName moduleNameStr) = moduleNameStr
+
+mkModulePathInfo :: ModuleName -> ModulePathInfo
+mkModulePathInfo (ModuleName moduleNameStr) =
+  let (dirMay, fileNoExtensionMay) =
+        foldl
+          ( \acc next ->
+              let dMay = case acc of
+                    (Nothing, Just prev) -> Just prev
+                    (Just dir, Just prev) -> Just $ dir </> prev
+                    (dMay', Nothing) -> dMay'
+               in (dMay, Just $ T.unpack next)
+          )
+          (Nothing, Nothing)
+          . T.splitOn "."
+          . T.pack
+          $ moduleNameStr
+   in ModulePathInfo (dirMay, Maybe.fromMaybe moduleNameStr fileNoExtensionMay)
+
+getModuleInfoPath :: ModulePathInfo -> Maybe String -> String -> FilePath
+getModuleInfoPath (ModulePathInfo (dirMay, fileNoExtension)) suffixMay extension =
+  let file = case suffixMay of
+        Nothing -> fileNoExtension <> extension
+        Just suffix -> fileNoExtension </> suffix <> extension
+   in maybe file (</> file) dirMay
+
+getModuleInfoDir :: ModulePathInfo -> FilePath
+getModuleInfoDir (ModulePathInfo (dirMay, fileNoExtension)) =
+  maybe fileNoExtension (</> fileNoExtension) dirMay
 
 data FixedValueStrategy = FixedValueStrategyExclude | FixedValueStrategyInclude
   deriving (Eq, Bounded, Enum)


### PR DESCRIPTION
Support compound top-level module names like `Foo.Bar.Baz`.

@joel-bach 