### PR TITLE
include `example/generatedCode` in `cabal.project`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,4 @@
-packages: */*.cabal
+packages:
+  */*.cabal
+  example/generatedCode/openapi.cabal
 test-show-details: direct


### PR DESCRIPTION
This PR allows the `example/generatedCode` package to be built with Cabal. I assume it is already working with the provided Stack config.

With this PR:
* `cabal build` succeeds in `generatedCode` dir
* `cabal build all` is fine as before in root dir

-----------

Before:
```
$ pwd
example/generatedCode

$ cabal build 
Configuration is affected by the following files:
- cabal.project
Error: [Cabal-7134]
No targets given and there is no package in the current directory. Use the target 'all' for all packages in the project or specify packages or components by name or location. See 'cabal build --help' for more details on target options.
```

`cabal build openapi` also did not work:
```
$ cabal build  openapi
Configuration is affected by the following files:
- cabal.project
Resolving dependencies...
Error: [Cabal-7127]
Cannot build the package openapi, it is not in this project (either directly or indirectly). If you want to add it to the project then edit the cabal.project file.
```

-------------

Double asterisk does not solve it:
```
packages: **/*.cabal
```
